### PR TITLE
Fix pattern_in_region_char()

### DIFF
--- a/autoload/vital/__latest__/Coaster/Search.vim
+++ b/autoload/vital/__latest__/Coaster/Search.vim
@@ -33,12 +33,12 @@ function! s:pattern_in_region_char(first, last, pattern)
 	elseif a:first[0] == a:last[0]
 		return printf('\%%%dl\%%>%dv\%%(%s\M\)\%%<%dv', a:first[0], a:first[1]-1, a:pattern, a:last[1]+1)
 	elseif a:last[0] - a:first[0] == 1
-		return  printf('\%%%dl\%%(%s\M\)\%%>%dv', a:first[0], a:pattern, a:first[1]-1)
+		return  printf('\%%%dl\%%>%dv\%%(%s\M\)', a:first[0], a:first[1]-1, a:pattern)
 \		. "\\|" . printf('\%%%dl\%%(%s\M\)\%%<%dv', a:last[0], a:pattern, a:last[1]+1)
 	else
-		return  printf('\%%%dl\%%(%s\M\)\%%>%dv', a:first[0], a:pattern, a:first[1]-1)
+		return  printf('\%%%dl\%%>%dv\%%(%s\M\)', a:first[0], a:first[1]-1, a:pattern)
 \		. "\\|" . printf('\%%>%dl\%%(%s\M\)\%%<%dl', a:first[0], a:pattern, a:last[0])
-\		. >"\\|" . printf('\%%%dl\%%(%s\M\)\%%<%dv', a:last[0], a:pattern, a:last[1]+1)
+\		. "\\|" . printf('\%%%dl\%%(%s\M\)\%%<%dv', a:last[0], a:pattern, a:last[1]+1)
 	endif
 endfunction
 


### PR DESCRIPTION
1. Fix a generated pattern matches a text before region in first line
2. Remove unexpected `>`

pattern_in_region_char() バグってたっぽいので修正しました．
regionが複数行で最初の行のfirstより前のテキストにマッチしないようにしました．
